### PR TITLE
feat: Add MGO message structs

### DIFF
--- a/tppmessage/CMD_DELETE_MGO_CHARACTER.go
+++ b/tppmessage/CMD_DELETE_MGO_CHARACTER.go
@@ -1,0 +1,16 @@
+package tppmessage
+
+type CmdDeleteMgoCharacterRequest struct {
+	Msgid          string `json:"msgid"`
+	Rqid           int    `json:"rqid"`
+	CharacterIndex int    `json:"characterIndex"`
+}
+
+type CmdDeleteMgoCharacterResponse struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_BOOST.go
+++ b/tppmessage/CMD_GET_MGO_BOOST.go
@@ -1,0 +1,16 @@
+package tppmessage
+
+type CmdGetMgoBoostRequest struct {
+	Msgid     string `json:"msgid"`
+	Rqid      int    `json:"rqid"`
+	BoostType int    `json:"boost_type"`
+}
+
+type CmdGetMgoBoostResponse struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_CHARACTER2.go
+++ b/tppmessage/CMD_GET_MGO_CHARACTER2.go
@@ -1,0 +1,18 @@
+package tppmessage
+
+type CmdGetMgoCharacter2Request struct {
+	Msgid string `json:"msgid"`
+	Rqid  int    `json:"rqid"`
+}
+
+type CmdGetMgoCharacter2Response struct {
+	// Character's structure is defined in an external JSON file (default_character.json)
+	// which is not available in the repository. Using interface{} to accommodate any valid JSON.
+	Character   interface{} `json:"character"`
+	CryptoType  string      `json:"crypto_type"`
+	Flowid      interface{} `json:"flowid"`
+	Msgid       string      `json:"msgid"`
+	Result      string      `json:"result"`
+	Rqid        int         `json:"rqid"`
+	Xuid        interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_GP.go
+++ b/tppmessage/CMD_GET_MGO_GP.go
@@ -1,0 +1,16 @@
+package tppmessage
+
+type CmdGetMgoGpRequest struct {
+	Msgid string `json:"msgid"`
+	Rqid  int    `json:"rqid"`
+}
+
+type CmdGetMgoGpResponse struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Gp         int         `json:"gp"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_LOADOUT.go
+++ b/tppmessage/CMD_GET_MGO_LOADOUT.go
@@ -1,0 +1,18 @@
+package tppmessage
+
+type CmdGetMgoLoadoutRequest struct {
+	Msgid string `json:"msgid"`
+	Rqid  int    `json:"rqid"`
+}
+
+type CmdGetMgoLoadoutResponse struct {
+	// Loadout's structure is defined in an external JSON file (default_loadout.json)
+	// which is not available in the repository. Using interface{} to accommodate any valid JSON.
+	Loadout    interface{} `json:"loadout"`
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_MATCH_STAT.go
+++ b/tppmessage/CMD_GET_MGO_MATCH_STAT.go
@@ -1,0 +1,29 @@
+package tppmessage
+
+type CmdGetMgoMatchStatRequest struct {
+	Msgid  string `json:"msgid"`
+	Rqid   int    `json:"rqid"`
+	Target struct {
+		NpID struct {
+			Handler struct {
+				Data string `json:"data"`
+				Term int    `json:"term"`
+			} `json:"handler"`
+		} `json:"np_id"`
+		PlayerID int `json:"player_id"`
+		SteamID  int `json:"steam_id"`
+		Xuid     int `json:"xuid"`
+	} `json:"target"`
+}
+
+type CmdGetMgoMatchStatResponse struct {
+	Abandon    int         `json:"abandon"`
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Played     int         `json:"played"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Started    int         `json:"started"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_MISSION_INFO.go
+++ b/tppmessage/CMD_GET_MGO_MISSION_INFO.go
@@ -1,0 +1,42 @@
+package tppmessage
+
+type CmdGetMgoMissionInfoRequest struct {
+	Msgid          string `json:"msgid"`
+	Rqid           int    `json:"rqid"`
+	MatchType      int    `json:"match_type"`
+	RuleType       int    `json:"rule_type"`
+	SurvivalParams struct {
+		CurrentSurvivalWins int    `json:"current_survival_wins"`
+		EarnedSurvivalGp    int    `json:"earned_survival_gp"`
+		RewardCategory      string `json:"reward_category"`
+		RewardIdA           int    `json:"reward_id_a"`
+		RewardIdB           int    `json:"reward_id_b"`
+		RewardIdC           int    `json:"reward_id_c"`
+		SurvivalUpdateKey   int    `json:"survival_update_key"`
+	} `json:"survival_params"`
+}
+
+type CmdGetMgoMissionInfoResponse struct {
+	CryptoType    string      `json:"crypto_type"`
+	Flowid        interface{} `json:"flowid"`
+	GpBoostMag    int         `json:"gp_boost_mag"`
+	Msgid         string      `json:"msgid"`
+	RankParam     struct {
+		CurrentRankXp int   `json:"current_rank_xp"`
+		EarnedRankXp  int   `json:"earned_rank_xp"`
+		RankXpList    []int `json:"rank_xp_list"`
+	} `json:"rank_param"`
+	Result        string `json:"result"`
+	Rqid          int    `json:"rqid"`
+	SurvivalParams struct {
+		CurrentSurvivalWins int    `json:"current_survival_wins"`
+		EarnedSurvivalGp    int    `json:"earned_survival_gp"`
+		RewardCategory      string `json:"reward_category"`
+		RewardIdA           int    `json:"reward_id_a"`
+		RewardIdB           int    `json:"reward_id_b"`
+		RewardIdC           int    `json:"reward_id_c"`
+		SurvivalUpdateKey   int    `json:"survival_update_key"`
+	} `json:"survival_params"`
+	XpBoostMag int         `json:"xp_boost_mag"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_PARAMETERS.go
+++ b/tppmessage/CMD_GET_MGO_PARAMETERS.go
@@ -1,0 +1,19 @@
+package tppmessage
+
+type CmdGetMgoParametersRequest struct {
+	Msgid string `json:"msgid"`
+	Rqid  int    `json:"rqid"`
+}
+
+type CmdGetMgoParametersResponse struct {
+	MgoParameter []struct {
+		ID    uint32 `json:"id"`
+		Value int    `json:"value"`
+	} `json:"MgoParameter"`
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_PROGRESSION.go
+++ b/tppmessage/CMD_GET_MGO_PROGRESSION.go
@@ -1,0 +1,25 @@
+package tppmessage
+
+type CmdGetMgoProgressionRequest struct {
+	Msgid    string `json:"msgid"`
+	PlayerID int    `json:"player_id"`
+	Rqid     int    `json:"rqid"`
+}
+
+type CmdGetMgoProgressionResponse struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Progression struct {
+		CharacterList []struct {
+			Legendary int `json:"legendary"`
+			Prestige  int `json:"prestige"`
+			Xp        int `json:"xp"`
+		} `json:"character_list"`
+		PermanentUnlockList []uint32 `json:"permanent_unlock_list"`
+		Version             int64    `json:"version"`
+	} `json:"progression"`
+	Result string      `json:"result"`
+	Rqid   int         `json:"rqid"`
+	Xuid   interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_PURCHASABLE_GEAR.go
+++ b/tppmessage/CMD_GET_MGO_PURCHASABLE_GEAR.go
@@ -1,0 +1,29 @@
+package tppmessage
+
+type CmdGetMgoPurchasableGearRequest struct {
+	Msgid      string `json:"msgid"`
+	Rqid       int    `json:"rqid"`
+	GearIDList struct {
+		GearIDList []uint32 `json:"gear_id_list"`
+	} `json:"gear_id_list"`
+}
+
+type CmdGetMgoPurchasableGearResponse struct {
+	CryptoType          string      `json:"crypto_type"`
+	Flowid              interface{} `json:"flowid"`
+	Msgid               string      `json:"msgid"`
+	PurchasableGearList struct {
+		PurchasableGearList []struct {
+			AlreadyPurchased int    `json:"already_purchased"`
+			AlreadyReleased  int    `json:"already_released"`
+			DefaultColor     uint32 `json:"default_color"`
+			GearID           uint32 `json:"gear_id"`
+			Point            int    `json:"point"`
+			Prestige         int    `json:"prestige"`
+			PurchaseType     int    `json:"purchase_type"`
+		} `json:"purchasable_gear_list"`
+	} `json:"purchasable_gear_list"`
+	Result string      `json:"result"`
+	Rqid   int         `json:"rqid"`
+	Xuid   interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_PURCHASABLE_GEAR_COLOR.go
+++ b/tppmessage/CMD_GET_MGO_PURCHASABLE_GEAR_COLOR.go
@@ -1,0 +1,29 @@
+package tppmessage
+
+type CmdGetMgoPurchasableGearColorRequest struct {
+	Msgid  string `json:"msgid"`
+	Rqid   int    `json:"rqid"`
+	GearID uint32 `json:"gear_id"`
+}
+
+type CmdGetMgoPurchasableGearColorResponse struct {
+	CryptoType           string      `json:"crypto_type"`
+	Flowid               interface{} `json:"flowid"`
+	Msgid                string      `json:"msgid"`
+	PurchasableGearColor struct {
+		AlreadyReleased      int    `json:"already_released"`
+		GearID               uint32 `json:"gear_id"`
+		PurchasableColorList []struct {
+			AlreadyPurchased int    `json:"already_purchased"`
+			Color            uint32 `json:"color"`
+			Level            int    `json:"level"`
+			Point            int    `json:"point"`
+			Prestige         int    `json:"prestige"`
+			PurchaseType     int    `json:"purchase_type"`
+		} `json:"purchasable_color_list"`
+		ReleaseDate int `json:"release_date"`
+	} `json:"purchasable_gear_color"`
+	Result string      `json:"result"`
+	Rqid   int         `json:"rqid"`
+	Xuid   interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_PURCHASABLE_ITEM_LIST.go
+++ b/tppmessage/CMD_GET_MGO_PURCHASABLE_ITEM_LIST.go
@@ -1,0 +1,24 @@
+package tppmessage
+
+type CmdGetMgoPurchasableItemListRequest struct {
+	Msgid      string `json:"msgid"`
+	Rqid       int    `json:"rqid"`
+	PurchaseID int    `json:"purchase_id"`
+}
+
+type CmdGetMgoPurchasableItemListResponse struct {
+	CryptoType          string      `json:"crypto_type"`
+	Flowid              interface{} `json:"flowid"`
+	Msgid               string      `json:"msgid"`
+	PurchasableItemList struct {
+		PurchasableItemList []struct {
+			Category     int `json:"category"`
+			Price        int `json:"price"`
+			PurchaseID   int `json:"purchase_id"`
+			PurchaseType int `json:"purchase_type"`
+		} `json:"purchasable_item_list"`
+	} `json:"purchasable_item_list"`
+	Result string      `json:"result"`
+	Rqid   int         `json:"rqid"`
+	Xuid   interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_PURCHASABLE_WEAPON_COLOR.go
+++ b/tppmessage/CMD_GET_MGO_PURCHASABLE_WEAPON_COLOR.go
@@ -1,0 +1,29 @@
+package tppmessage
+
+type CmdGetMgoPurchasableWeaponColorRequest struct {
+	Msgid    string `json:"msgid"`
+	Rqid     int    `json:"rqid"`
+	WeaponID int    `json:"weapon_id"`
+}
+
+type CmdGetMgoPurchasableWeaponColorResponse struct {
+	CryptoType             string      `json:"crypto_type"`
+	Flowid                 interface{} `json:"flowid"`
+	Msgid                  string      `json:"msgid"`
+	PurchasableWeaponColor struct {
+		AlreadyReleased      int    `json:"already_released"`
+		PurchasableColorList []struct {
+			AlreadyPurchased int    `json:"already_purchased"`
+			Color            uint32 `json:"color"`
+			Level            int    `json:"level"`
+			Point            int    `json:"point"`
+			Prestige         int    `json:"prestige"`
+			PurchaseType     int    `json:"purchase_type"`
+		} `json:"purchasable_color_list"`
+		ReleaseDate int `json:"release_date"`
+		WeaponID    int `json:"weapon_id"`
+	} `json:"purchasable_weapon_color"`
+	Result string      `json:"result"`
+	Rqid   int         `json:"rqid"`
+	Xuid   interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_PURCHASED_ITEM.go
+++ b/tppmessage/CMD_GET_MGO_PURCHASED_ITEM.go
@@ -1,0 +1,25 @@
+package tppmessage
+
+type CmdGetMgoPurchasedItemRequest struct {
+	Msgid      string `json:"msgid"`
+	Rqid       int    `json:"rqid"`
+	Category   int    `json:"category"`
+	PurchaseID int    `json:"purchase_id"`
+}
+
+type CmdGetMgoPurchasedItemResponse struct {
+	CryptoType          string      `json:"crypto_type"`
+	Flowid              interface{} `json:"flowid"`
+	Msgid               string      `json:"msgid"`
+	PurchasableItemList struct {
+		PurchasableItemList []struct {
+			Category     int `json:"category"`
+			Price        int `json:"price"`
+			PurchaseID   int `json:"purchase_id"`
+			PurchaseType int `json:"purchase_type"`
+		} `json:"purchasable_item_list"`
+	} `json:"purchasable_item_list"`
+	Result string      `json:"result"`
+	Rqid   int         `json:"rqid"`
+	Xuid   interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_STAT.go
+++ b/tppmessage/CMD_GET_MGO_STAT.go
@@ -1,0 +1,39 @@
+package tppmessage
+
+type CmdGetMgoStatRequest struct {
+	Msgid  string `json:"msgid"`
+	Rqid   int    `json:"rqid"`
+	Target struct {
+		NpID struct {
+			Handler struct {
+				Data string `json:"data"`
+				Term int    `json:"term"`
+			} `json:"handler"`
+		} `json:"np_id"`
+		PlayerID int `json:"player_id"`
+		SteamID  int `json:"steam_id"`
+		Xuid     int `json:"xuid"`
+	} `json:"target"`
+}
+
+type MgoStat struct {
+	RuleStatList []struct {
+		ID       uint32 `json:"id"`
+		RuleCode uint32 `json:"rule_code"`
+		Value    int    `json:"value"`
+	} `json:"rule_stat_list"`
+	StatList []struct {
+		ID    uint32 `json:"id"`
+		Value int    `json:"value"`
+	} `json:"stat_list"`
+}
+
+type CmdGetMgoStatResponse struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Stat       MgoStat     `json:"stat"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_TITLE_LIST.go
+++ b/tppmessage/CMD_GET_MGO_TITLE_LIST.go
@@ -1,0 +1,20 @@
+package tppmessage
+
+type CmdGetMgoTitleListRequest struct {
+	Msgid string `json:"msgid"`
+	Rqid  int    `json:"rqid"`
+}
+
+type CmdGetMgoTitleListResponse struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	TitleList  []struct {
+		Flag int `json:"flag"`
+		Gp   int `json:"gp"`
+		ID   int `json:"id"`
+	} `json:"title_list"`
+	Xuid interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_TITLE_USR.go
+++ b/tppmessage/CMD_GET_MGO_TITLE_USR.go
@@ -1,0 +1,31 @@
+package tppmessage
+
+type CmdGetMgoTitleUsrRequest struct {
+	Msgid  string `json:"msgid"`
+	Rqid   int    `json:"rqid"`
+	Target struct {
+		NpID struct {
+			Handler struct {
+				Data string `json:"data"`
+				Term int    `json:"term"`
+			} `json:"handler"`
+		} `json:"np_id"`
+		PlayerID int `json:"player_id"`
+		SteamID  int `json:"steam_id"`
+		Xuid     int `json:"xuid"`
+	} `json:"target"`
+}
+
+type CmdGetMgoTitleUsrResponse struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	TitleList  []struct {
+		Flag int `json:"flag"`
+		Gp   int `json:"gp"`
+		ID   int `json:"id"`
+	} `json:"title_list"`
+	Xuid interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_GET_MGO_USER_DATA.go
+++ b/tppmessage/CMD_GET_MGO_USER_DATA.go
@@ -1,0 +1,30 @@
+package tppmessage
+
+type CmdGetMgoUserDataRequest struct {
+	Msgid string `json:"msgid"`
+	Rqid  int    `json:"rqid"`
+}
+
+type CmdGetMgoUserDataResponse struct {
+	CryptoType            string      `json:"crypto_type"`
+	Flowid                interface{} `json:"flowid"`
+	Gp                    int         `json:"gp"`
+	GpBoostMag            int         `json:"gp_boost_mag"`
+	GpExpire              string      `json:"gp_expire"`
+	GpExpireUnixTimestamp int         `json:"gp_expire_unix_timestamp"`
+	Msgid                 string      `json:"msgid"`
+	RankXp                int         `json:"rank_xp"`
+	Result                string      `json:"result"`
+	Reward                struct {
+		RewardCategory string `json:"reward_category"`
+		RewardIdA      uint32 `json:"reward_id_a"`
+		RewardIdB      int    `json:"reward_id_b"`
+		RewardIdC      int    `json:"reward_id_c"`
+	} `json:"reward"`
+	Rqid                 int         `json:"rqid"`
+	SurvivalTicketRemain int         `json:"survival_ticket_remain"`
+	XpBoostMag           int         `json:"xp_boost_mag"`
+	XpExpire             string      `json:"xp_expire"`
+	XpExpireUnixTimestamp int         `json:"xp_expire_unix_timestamp"`
+	Xuid                 interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_MGO_DLC_UPDATE.go
+++ b/tppmessage/CMD_MGO_DLC_UPDATE.go
@@ -1,0 +1,19 @@
+package tppmessage
+
+type CmdMgoDlcUpdateRequest struct {
+	Msgid    string `json:"msgid"`
+	Rqid     int    `json:"rqid"`
+	PlayerID int    `json:"player_id"`
+	DlcFlags int    `json:"dlc_flags"`
+}
+
+type CmdMgoDlcUpdateResponse struct {
+	CryptoType  string      `json:"crypto_type"`
+	Flowid      interface{} `json:"flowid"`
+	Msgid       string      `json:"msgid"`
+	NowDlcFlags int         `json:"now_dlc_flags"`
+	OldDlcFlags int         `json:"old_dlc_flags"`
+	Result      string      `json:"result"`
+	Rqid        int         `json:"rqid"`
+	Xuid        interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_MGO_MISSION_RESULT.go
+++ b/tppmessage/CMD_MGO_MISSION_RESULT.go
@@ -1,0 +1,47 @@
+package tppmessage
+
+type CmdMgoMissionResultRequest struct {
+	Msgid          string `json:"msgid"`
+	Rqid           int    `json:"rqid"`
+	CharacterIndex int    `json:"character_index"`
+	Code           int    `json:"code"`
+	EarnedGp       int    `json:"earned_gp"`
+	EarnedXp       int    `json:"earned_xp"`
+	RankParam      struct {
+		EarnedRankXp int `json:"earned_rank_xp"`
+	} `json:"rank_param"`
+	SurvivalParams struct {
+		EarnedSurvivalGp int `json:"earned_survival_gp"`
+	} `json:"survival_params"`
+	Ucd string `json:"ucd"`
+}
+
+type CmdMgoMissionResultResponse struct {
+	CharacterIndex int         `json:"character_index"`
+	Code           int         `json:"code"`
+	CryptoType     string      `json:"crypto_type"`
+	CurrentGp      int         `json:"current_gp"`
+	CurrentXp      int         `json:"current_xp"`
+	EarnedGp       int         `json:"earned_gp"`
+	EarnedXp       int         `json:"earned_xp"`
+	Flowid         interface{} `json:"flowid"`
+	Msgid          string      `json:"msgid"`
+	RankParam      struct {
+		CurrentRankXp int   `json:"current_rank_xp"`
+		EarnedRankXp  int   `json:"earned_rank_xp"`
+		RankXpList    []int `json:"rank_xp_list"`
+	} `json:"rank_param"`
+	Result         string `json:"result"`
+	Rqid           int    `json:"rqid"`
+	SurvivalParams struct {
+		CurrentSurvivalWins int    `json:"current_survival_wins"`
+		EarnedSurvivalGp    int    `json:"earned_survival_gp"`
+		RewardCategory      string `json:"reward_category"`
+		RewardIdA           int    `json:"reward_id_a"`
+		RewardIdB           int    `json:"reward_id_b"`
+		RewardIdC           int    `json:"reward_id_c"`
+		SurvivalUpdateKey   int    `json:"survival_update_key"`
+	} `json:"survival_params"`
+	Ucd  string      `json:"ucd"`
+	Xuid interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_SET_MGO_CHARACTER2.go
+++ b/tppmessage/CMD_SET_MGO_CHARACTER2.go
@@ -1,0 +1,18 @@
+package tppmessage
+
+type CmdSetMgoCharacter2Request struct {
+	Msgid string `json:"msgid"`
+	Rqid  int    `json:"rqid"`
+	// Character's structure is defined in an external JSON file (default_character.json)
+	// which is not available in the repository. Using interface{} to accommodate any valid JSON.
+	Character interface{} `json:"character"`
+}
+
+type CmdSetMgoCharacter2Response struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_SET_MGO_CHARACTER_AND_LOADOUT2.go
+++ b/tppmessage/CMD_SET_MGO_CHARACTER_AND_LOADOUT2.go
@@ -1,0 +1,21 @@
+package tppmessage
+
+type CmdSetMgoCharacterAndLoadout2Request struct {
+	Msgid string `json:"msgid"`
+	Rqid  int    `json:"rqid"`
+	// Character's structure is defined in an external JSON file (default_character.json)
+	// which is not available in the repository. Using interface{} to accommodate any valid JSON.
+	Character interface{} `json:"character"`
+	// Loadout's structure is defined in an external JSON file (default_loadout.json)
+	// which is not available in the repository. Using interface{} to accommodate any valid JSON.
+	Loadout interface{} `json:"loadout"`
+}
+
+type CmdSetMgoCharacterAndLoadout2Response struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_SET_MGO_MATCH_STAT.go
+++ b/tppmessage/CMD_SET_MGO_MATCH_STAT.go
@@ -1,0 +1,18 @@
+package tppmessage
+
+type CmdSetMgoMatchStatRequest struct {
+	Msgid   string `json:"msgid"`
+	Rqid    int    `json:"rqid"`
+	Abandon int    `json:"abandon"`
+	Played  int    `json:"played"`
+	Started int    `json:"started"`
+}
+
+type CmdSetMgoMatchStatResponse struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Xuid       interface{} `json:"xuid"`
+}

--- a/tppmessage/CMD_SET_MGO_STAT.go
+++ b/tppmessage/CMD_SET_MGO_STAT.go
@@ -1,0 +1,16 @@
+package tppmessage
+
+type CmdSetMgoStatRequest struct {
+	Msgid string  `json:"msgid"`
+	Rqid  int     `json:"rqid"`
+	Stat  MgoStat `json:"stat"`
+}
+
+type CmdSetMgoStatResponse struct {
+	CryptoType string      `json:"crypto_type"`
+	Flowid     interface{} `json:"flowid"`
+	Msgid      string      `json:"msgid"`
+	Result     string      `json:"result"`
+	Rqid       int         `json:"rqid"`
+	Xuid       interface{} `json:"xuid"`
+}


### PR DESCRIPTION
This commit adds the Go struct definitions for all Metal Gear Online (MGO) messages to the `tppmessage` package. The new structs are based on the reference Python implementation in the `mgo_reference` directory.

The following changes were made:
- Created 24 new Go files, one for each MGO command.
- Defined request and response structs for each command with appropriate JSON tags.
- Used `interface{}` for complex data structures (`Character`, `Loadout`) where the exact structure was not available in the repository, and added comments to explain this.
- Created a shared `MgoStat` struct to avoid code duplication.