### PR TITLE
feat: Add MGO character and loadout database schema

### DIFF
--- a/handlers/gate.go
+++ b/handlers/gate.go
@@ -25,6 +25,8 @@ import (
 	"github.com/unknown321/fuse/intruder"
 	"github.com/unknown321/fuse/localbase"
 	"github.com/unknown321/fuse/message"
+	"github.com/unknown321/fuse/mgo/character"
+	"github.com/unknown321/fuse/mgo/loadout"
 	"github.com/unknown321/fuse/motherbaseparam"
 	"github.com/unknown321/fuse/onlinechallengetask"
 	onlinechallengetaskplayer "github.com/unknown321/fuse/onlinechallengetask/player"
@@ -108,6 +110,8 @@ type GateHandler struct {
 	FOBPlacedRepo                 fobplaced.Repo
 	FOBWeaponPlacementRepo        fobweaponplacement.Repo
 	IntruderRepo                  intruder.Repo
+	MGOCharacterRepo              character.Repo
+	MGOLoadoutRepo                loadout.Repo
 }
 
 func (gh *GateHandler) WithManager(m *sessionmanager.SessionManager) {
@@ -154,6 +158,8 @@ func (gh *GateHandler) WithManager(m *sessionmanager.SessionManager) {
 	m.FOBPlacedRepo = &gh.FOBPlacedRepo
 	m.FOBWeaponPlacementRepo = &gh.FOBWeaponPlacementRepo
 	m.IntruderRepo = &gh.IntruderRepo
+	m.MGOCharacterRepo = &gh.MGOCharacterRepo
+	m.MGOLoadoutRepo = &gh.MGOLoadoutRepo
 }
 
 func (gh *GateHandler) WithCoder(c *coder.Coder) {

--- a/handlers/gate_init.go
+++ b/handlers/gate_init.go
@@ -180,6 +180,32 @@ func (gh *GateHandler) InitDB(ctx context.Context, baseURL string, platform stri
 		return fmt.Errorf("init intruder: %w", err)
 	}
 
+	if err = gh.initMGOCharacterRepo(ctx); err != nil {
+		return fmt.Errorf("init mgo character: %w", err)
+	}
+
+	if err = gh.initMGOLoadoutRepo(ctx); err != nil {
+		return fmt.Errorf("init mgo loadout: %w", err)
+	}
+
+	return nil
+}
+
+func (gh *GateHandler) initMGOCharacterRepo(ctx context.Context) error {
+	gh.MGOCharacterRepo.WithDB(gh.DB)
+	if err := gh.MGOCharacterRepo.Init(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (gh *GateHandler) initMGOLoadoutRepo(ctx context.Context) error {
+	gh.MGOLoadoutRepo.WithDB(gh.DB)
+	if err := gh.MGOLoadoutRepo.Init(ctx); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/mgo/character/character.go
+++ b/mgo/character/character.go
@@ -1,0 +1,88 @@
+package character
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"github.com/unknown321/fuse/player"
+	"github.com/unknown321/fuse/tppmessage"
+)
+
+type Repo struct {
+	db *sql.DB
+}
+
+func (r *Repo) WithDB(db *sql.DB) {
+	r.db = db
+}
+
+func (r *Repo) Init(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS mgo_character (
+			player_id INTEGER NOT NULL,
+			character_id INTEGER NOT NULL,
+			data BLOB,
+			PRIMARY KEY (player_id, character_id),
+			FOREIGN KEY (player_id) REFERENCES player(id)
+		)
+	`)
+	return err
+}
+
+func (r *Repo) Find(ctx context.Context, playerID player.ID, characterID int) (*tppmessage.MGOCharacter, error) {
+	row := r.db.QueryRowContext(ctx, "SELECT data FROM mgo_character WHERE player_id = ? AND character_id = ?", playerID, characterID)
+
+	var data []byte
+	err := row.Scan(&data)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var char tppmessage.MGOCharacter
+	if err := json.Unmarshal(data, &char); err != nil {
+		return nil, err
+	}
+
+	return &char, nil
+}
+
+func (r *Repo) Save(ctx context.Context, playerID player.ID, char *tppmessage.MGOCharacter) error {
+	data, err := json.Marshal(char)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO mgo_character (player_id, character_id, data)
+		VALUES (?, ?, ?)
+	`, playerID, char.CharacterID, data)
+
+	return err
+}
+
+func (r *Repo) FindAllByPlayer(ctx context.Context, playerID player.ID) ([]*tppmessage.MGOCharacter, error) {
+	rows, err := r.db.QueryContext(ctx, "SELECT data FROM mgo_character WHERE player_id = ?", playerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var chars []*tppmessage.MGOCharacter
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, err
+		}
+
+		var char tppmessage.MGOCharacter
+		if err := json.Unmarshal(data, &char); err != nil {
+			return nil, err
+		}
+		chars = append(chars, &char)
+	}
+
+	return chars, nil
+}

--- a/mgo/loadout/loadout.go
+++ b/mgo/loadout/loadout.go
@@ -1,0 +1,89 @@
+package loadout
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"github.com/unknown321/fuse/player"
+	"github.com/unknown321/fuse/tppmessage"
+)
+
+type Repo struct {
+	db *sql.DB
+}
+
+func (r *Repo) WithDB(db *sql.DB) {
+	r.db = db
+}
+
+func (r *Repo) Init(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS mgo_loadout (
+			player_id INTEGER NOT NULL,
+			character_id INTEGER NOT NULL,
+			loadout_index INTEGER NOT NULL,
+			data BLOB,
+			PRIMARY KEY (player_id, character_id, loadout_index),
+			FOREIGN KEY (player_id) REFERENCES player(id)
+		)
+	`)
+	return err
+}
+
+func (r *Repo) FindByCharacter(ctx context.Context, playerID player.ID, characterID int) ([]*tppmessage.MGOLoadout, error) {
+	rows, err := r.db.QueryContext(ctx, "SELECT data FROM mgo_loadout WHERE player_id = ? AND character_id = ?", playerID, characterID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var loadouts []*tppmessage.MGOLoadout
+	for rows.Next() {
+		var data []byte
+		if err := rows.Scan(&data); err != nil {
+			return nil, err
+		}
+
+		var loadout tppmessage.MGOLoadout
+		if err := json.Unmarshal(data, &loadout); err != nil {
+			return nil, err
+		}
+		loadouts = append(loadouts, &loadout)
+	}
+
+	return loadouts, nil
+}
+
+func (r *Repo) Save(ctx context.Context, playerID player.ID, characterID int, loadout *tppmessage.MGOLoadout) error {
+	data, err := json.Marshal(loadout)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO mgo_loadout (player_id, character_id, loadout_index, data)
+		VALUES (?, ?, ?, ?)
+	`, playerID, characterID, loadout.LoadoutIndex, data)
+
+	return err
+}
+
+func (r *Repo) Find(ctx context.Context, playerID player.ID, characterID int, loadoutIndex int) (*tppmessage.MGOLoadout, error) {
+	row := r.db.QueryRowContext(ctx, "SELECT data FROM mgo_loadout WHERE player_id = ? AND character_id = ? AND loadout_index = ?", playerID, characterID, loadoutIndex)
+
+	var data []byte
+	err := row.Scan(&data)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var loadout tppmessage.MGOLoadout
+	if err := json.Unmarshal(data, &loadout); err != nil {
+		return nil, err
+	}
+
+	return &loadout, nil
+}

--- a/player/player.go
+++ b/player/player.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 )
 
+type ID int
+
 type Sneak struct {
 	Grade int
 	Rank  int

--- a/sessionmanager/sessionmanager.go
+++ b/sessionmanager/sessionmanager.go
@@ -27,6 +27,8 @@ import (
 	"github.com/unknown321/fuse/intruder"
 	"github.com/unknown321/fuse/localbase"
 	"github.com/unknown321/fuse/message"
+	"github.com/unknown321/fuse/mgo/character"
+	"github.com/unknown321/fuse/mgo/loadout"
 	"github.com/unknown321/fuse/motherbaseparam"
 	"github.com/unknown321/fuse/onlinechallengetask"
 	onlinechallengetaskplayer "github.com/unknown321/fuse/onlinechallengetask/player"
@@ -116,6 +118,8 @@ type SessionManager struct {
 	FOBPlacedRepo                 *fobplaced.Repo
 	FOBWeaponPlacementRepo        *fobweaponplacement.Repo
 	IntruderRepo                  *intruder.Repo
+	MGOCharacterRepo              *character.Repo
+	MGOLoadoutRepo                *loadout.Repo
 	LogDir                        string
 }
 

--- a/tppmessage/CMD_GET_MGO_CHARACTER2.go
+++ b/tppmessage/CMD_GET_MGO_CHARACTER2.go
@@ -6,10 +6,8 @@ type CmdGetMgoCharacter2Request struct {
 }
 
 type CmdGetMgoCharacter2Response struct {
-	// Character's structure is defined in an external JSON file (default_character.json)
-	// which is not available in the repository. Using interface{} to accommodate any valid JSON.
-	Character   interface{} `json:"character"`
-	CryptoType  string      `json:"crypto_type"`
+	Character   MGOCharacterData `json:"character"`
+	CryptoType  string           `json:"crypto_type"`
 	Flowid      interface{} `json:"flowid"`
 	Msgid       string      `json:"msgid"`
 	Result      string      `json:"result"`

--- a/tppmessage/CMD_GET_MGO_LOADOUT.go
+++ b/tppmessage/CMD_GET_MGO_LOADOUT.go
@@ -6,10 +6,8 @@ type CmdGetMgoLoadoutRequest struct {
 }
 
 type CmdGetMgoLoadoutResponse struct {
-	// Loadout's structure is defined in an external JSON file (default_loadout.json)
-	// which is not available in the repository. Using interface{} to accommodate any valid JSON.
-	Loadout    interface{} `json:"loadout"`
-	CryptoType string      `json:"crypto_type"`
+	Loadout    MGOLoadoutData `json:"loadout"`
+	CryptoType string         `json:"crypto_type"`
 	Flowid     interface{} `json:"flowid"`
 	Msgid      string      `json:"msgid"`
 	Result     string      `json:"result"`

--- a/tppmessage/mgo_types.go
+++ b/tppmessage/mgo_types.go
@@ -1,0 +1,125 @@
+package tppmessage
+
+// MGOUserData is for CMD_GET_MGO_USER_DATA
+type MGOUserData struct {
+	Name     string `json:"name"`
+	PlayTime int    `json:"play_time"`
+	Version  int    `json:"version"`
+}
+
+// MGOCharacterData represents the entire character data structure from default_character.json
+type MGOCharacterData struct {
+	Match               MatchData        `json:"match"`
+	Version             int64            `json:"version"`
+	LastActive          int              `json:"last_active"`
+	SelectedBgm         int              `json:"selected_bgm"`
+	CharacterList       []MGOCharacter   `json:"character_list"`
+	PresetRadioRuleList []PresetRadioSet `json:"preset_radio_rule_list"`
+}
+
+type MatchData struct {
+	AutoLeave        int           `json:"auto_leave"`
+	PlayerNum        int           `json:"player_num"`
+	HostComment      int           `json:"host_comment"`
+	MaxCapacity      int           `json:"max_capacity"`
+	BriefingTime     int           `json:"briefing_time"`
+	MissionSlotList  []MissionSlot `json:"mission_slot_list"`
+	MissionSlotCount int           `json:"mission_slot_count"`
+}
+
+type MissionSlot struct {
+	Map             int `json:"map"`
+	Rule            int `json:"rule"`
+	Rush            int `json:"rush"`
+	Time            int `json:"time"`
+	Flags           int `json:"flags"`
+	Night           int `json:"night"`
+	Ticket          int `json:"ticket"`
+	Weather         int `json:"weather"`
+	UniqueCharacter int `json:"unique_character"`
+}
+
+// MGOCharacter represents a single character from the character_list
+type MGOCharacter struct {
+	CharacterID int    `json:"-"` // Not in original JSON, for DB use
+	Name        string `json:"name"`
+	Avatar      Avatar `json:"avatar"`
+	PlayerType  int    `json:"player_type"`
+	LastLoadout int    `json:"last_loadout"`
+	PlayerClass int    `json:"player_class"`
+}
+
+type Avatar struct {
+	Voice                 int   `json:"voice"`
+	FaceRace              int   `json:"face_race"`
+	FaceType              int   `json:"face_type"`
+	FaceColor             int   `json:"face_color"`
+	HairColor             int   `json:"hair_color"`
+	HairStyle             int   `json:"hair_style"`
+	BeardStyle            int   `json:"beard_style"`
+	BeardLength           int   `json:"beard_length"`
+	TattooColor           int   `json:"tattoo_color"`
+	EyebrowStyle          int   `json:"eyebrow_style"`
+	EyebrowWidth          int   `json:"eyebrow_width"`
+	FaceVariation         int   `json:"face_variation"`
+	LeftEyeColor          int   `json:"left_eye_color"`
+	AccessoryFlags        int   `json:"accessory_flags"`
+	RightEyeColor         int   `json:"right_eye_color"`
+	MotionFrameList       []int `json:"motion_frame_list"`
+	LeftEyeBrightness     int   `json:"left_eye_brightness"`
+	RightEyeBrightness    int   `json:"right_eye_brightness"`
+	GashOrTattooVariation int   `json:"gash_or_tattoo_variation"`
+}
+
+type PresetRadioSet struct {
+	PresetRadioIDList []int `json:"preset_radio_id_list"`
+}
+
+// MGOLoadoutData represents the entire loadout data structure from default_loadout.json
+type MGOLoadoutData struct {
+	Version       int64               `json:"version"`
+	CharacterList []CharacterLoadouts `json:"character_list"`
+}
+
+type CharacterLoadouts struct {
+	LoadoutList []MGOLoadout `json:"loadout_list"`
+}
+
+// MGOLoadout represents a single loadout.
+type MGOLoadout struct {
+	LoadoutIndex      int             `json:"-"` // Not in original JSON, for DB use
+	Name              string          `json:"name"`
+	GearList          []Gear          `json:"gear_list"`
+	ItemList          []Item          `json:"item_list"`
+	SkillList         []Skill         `json:"skill_list"`
+	WeaponList        []Weapon        `json:"weapon_list"`
+	SupportWeaponList []SupportWeapon `json:"support_weapon_list"`
+}
+
+type Gear struct {
+	ID        uint   `json:"id"`
+	Model     uint32 `json:"model"`
+	ColorList []uint `json:"color_list"`
+}
+
+type Item struct {
+	ID   uint32 `json:"id"`
+	Slot int    `json:"slot"`
+}
+
+type Skill struct {
+	ID   uint32 `json:"id"`
+	Slot int    `json:"slot"`
+}
+
+type Weapon struct {
+	ID        uint32   `json:"id"`
+	Slot      int      `json:"slot"`
+	PartList  []uint32 `json:"part_list,omitempty"`
+	ColorList []uint   `json:"color_list,omitempty"`
+}
+
+type SupportWeapon struct {
+	ID   uint32 `json:"id"`
+	Slot int    `json:"slot"`
+}


### PR DESCRIPTION
This change introduces the necessary database schema and repositories to support MGO characters and loadouts.

Key changes include:
- Created `mgo/character` and `mgo/loadout` packages with repositories to manage database interactions.
- Defined `MGOCharacterData` and `MGOLoadoutData` structs in `tppmessage/mgo_types.go` based on the provided JSON reference files.
- Updated `CMD_GET_MGO_CHARACTER2` and `CMD_GET_MGO_LOADOUT` response structs to use the new strongly-typed data structures.
- Integrated the new repositories into the `GateHandler` and `SessionManager` to make them accessible to command handlers.
- Added a `player.ID` type to improve type safety.